### PR TITLE
Fix left nav tests

### DIFF
--- a/cypress/e2e/privatePaths/render/deployment/workbench.spec.ts
+++ b/cypress/e2e/privatePaths/render/deployment/workbench.spec.ts
@@ -42,7 +42,6 @@ describe(pageName, () => {
     false,
     true,
     loggedIn,
-    true,
   );
   runTestsForDevices({ currentPage, devices });
 });

--- a/cypress/e2e/utils/devices.ts
+++ b/cypress/e2e/utils/devices.ts
@@ -100,15 +100,8 @@ export const desktopDevicesForAppLayout = (
   skipNavbar = false,
   skipFooter = false,
   loggedIn = false,
-  hasClosedLeftNav = false,
 ) => {
-  const t = getAppLayoutTests(
-    tests,
-    skipNavbar,
-    skipFooter,
-    loggedIn,
-    hasClosedLeftNav,
-  );
+  const t = getAppLayoutTests(tests, skipNavbar, skipFooter, loggedIn);
   return [macbook15(pageName, t, loggedIn), macbook11(pageName, t, loggedIn)];
 };
 
@@ -119,7 +112,6 @@ export const allDevicesForAppLayout = (
   skipNavbar = false,
   skipFooter = false,
   loggedIn = false,
-  hasClosedLeftNav = false,
 ) => [
   ...desktopDevicesForAppLayout(
     pageName,
@@ -127,7 +119,6 @@ export const allDevicesForAppLayout = (
     skipNavbar,
     skipFooter,
     loggedIn,
-    hasClosedLeftNav,
   ),
   ...mobileDevicesForAppLayout(
     pageName,
@@ -143,13 +134,10 @@ function getAppLayoutTests(
   skipNavbar = false,
   skipFooter = false,
   loggedIn = false,
-  hasClosedLeftNav = false,
 ) {
   if (skipNavbar && skipFooter) return tests;
   if (skipNavbar) return [...tests, ...testFooter];
-  const navbarTests = loggedIn
-    ? testSignedInNavbar(hasClosedLeftNav)
-    : testSignedOutNavbar;
+  const navbarTests = loggedIn ? testSignedInNavbar : testSignedOutNavbar;
   if (skipFooter) return [...navbarTests, ...tests];
   return [...navbarTests, ...tests, ...testFooter];
 }

--- a/cypress/e2e/utils/sharedTests/navbar.ts
+++ b/cypress/e2e/utils/sharedTests/navbar.ts
@@ -48,17 +48,7 @@ export const testSignedOutNavbar: Tests = [
   ),
 ];
 
-export const testSignedInNavbar = (hasClosedLeftNav = false): Tests => [
-  ...(hasClosedLeftNav
-    ? [
-        newExpectationWithClickFlows(
-          "should open left nav",
-          "[data-cy=left-navbar-open-button]",
-          beVisible,
-          [newClickFlow("[data-cy=left-navbar-open-button]", [])],
-        ),
-      ]
-    : []),
+export const testSignedInNavbar: Tests = [
   newExpectation(
     "should have signed in navbar and correct links",
     signedInLinks,


### PR DESCRIPTION
Left nav will now default to open for every page since we're storing that variable in the session state and it's cleared for each cypress run