### PR TITLE
Update create deployment cost tests for 10x pricing multiplier

### DIFF
--- a/cypress/e2e/privatePaths/render/createDeployment/fromBackup.spec.ts
+++ b/cypress/e2e/privatePaths/render/createDeployment/fromBackup.spec.ts
@@ -4,7 +4,10 @@ import {
 } from "@sharedTests/sharedFunctionsAndVariables";
 import { allDevicesForAppLayout } from "@utils/devices";
 import { runTestsForDevices } from "@utils/index";
-import { testAboutTab, testConfirmTab } from "@utils/sharedTests/createDep";
+import {
+  testAboutTab,
+  testConfirmTabWithoutCostPerms,
+} from "@utils/sharedTests/createDep";
 
 const pageName = "Create deployment page with existing deployment params";
 const ownerName = "automated_testing";
@@ -23,7 +26,7 @@ describe(pageName, () => {
 
     ...testAboutTab(ownerName, `${depName}-1`),
     // Skip to Confirm
-    ...testConfirmTab(),
+    ...testConfirmTabWithoutCostPerms(ownerName),
   ];
 
   const devices = allDevicesForAppLayout(pageName, tests, tests);

--- a/cypress/e2e/privatePaths/render/createDeployment/fromExistingDep.spec.ts
+++ b/cypress/e2e/privatePaths/render/createDeployment/fromExistingDep.spec.ts
@@ -4,7 +4,10 @@ import {
 } from "@sharedTests/sharedFunctionsAndVariables";
 import { allDevicesForAppLayout } from "@utils/devices";
 import { runTestsForDevices } from "@utils/index";
-import { testAboutTab, testConfirmTab } from "@utils/sharedTests/createDep";
+import {
+  testAboutTab,
+  testConfirmTabWithoutCostPerms,
+} from "@utils/sharedTests/createDep";
 
 const pageName = "Create deployment page with existing deployment params";
 const ownerName = "automated_testing";
@@ -22,7 +25,7 @@ describe(pageName, () => {
 
     ...testAboutTab(ownerName, `${depName}-1`),
     // Skip to Confirm
-    ...testConfirmTab(),
+    ...testConfirmTabWithoutCostPerms(ownerName),
   ];
 
   const devices = allDevicesForAppLayout(pageName, tests, tests);

--- a/cypress/e2e/privatePaths/render/createDeployment/withWebpki.spec.ts
+++ b/cypress/e2e/privatePaths/render/createDeployment/withWebpki.spec.ts
@@ -4,7 +4,10 @@ import {
 } from "@sharedTests/sharedFunctionsAndVariables";
 import { allDevicesForAppLayout } from "@utils/devices";
 import { runTestsForDevices } from "@utils/index";
-import { testAboutTab, testConfirmTab } from "@utils/sharedTests/createDep";
+import {
+  testAboutTab,
+  testConfirmTabWithoutCostPerms,
+} from "@utils/sharedTests/createDep";
 
 const pageName = "Create deployment page with existing deployment params";
 const ownerName = "automated_testing";
@@ -23,7 +26,7 @@ describe(pageName, () => {
 
     ...testAboutTab(ownerName, `${depName}-1`),
     // Skip to Confirm
-    ...testConfirmTab(),
+    ...testConfirmTabWithoutCostPerms(ownerName),
   ];
 
   const devices = allDevicesForAppLayout(pageName, tests, tests);

--- a/cypress/e2e/utils/sharedTests/createDep.ts
+++ b/cypress/e2e/utils/sharedTests/createDep.ts
@@ -77,13 +77,30 @@ export const testAdvancedTab = (mobile = false): Tests => [
   shouldClickAndFind("next-advanced", "confirm-deployment"),
 ];
 
+// Costs are quoted with the billing owner's pricing multiplier, which defaults
+// to 10x. Owners predating that default are grandfathered into a lower
+// multiplier, so a grandfathered owner needs its cost passed in explicitly.
 export const testConfirmTab = (cost?: string): Tests => [
   scrollToPosition("#main-content", "top"),
   shouldFindAndContain("active-tab", "Confirm"),
   shouldNotExist("error-msg"),
   shouldFindAndContain("hourly-cost", [
     "Hourly cost:",
-    `$${cost ?? "0.67"} + egress`,
+    `$${cost ?? "1.11"} + egress`,
   ]),
+  shouldFindAndScrollTo("create-deployment-button"),
+];
+
+// Quoting costs needs the owner's pricing multiplier, so it is only allowed for
+// owners of the organization the deployment would belong to. Non-owners get an
+// error in place of the cost breakdown.
+export const testConfirmTabWithoutCostPerms = (ownerName: string): Tests => [
+  scrollToPosition("#main-content", "top"),
+  shouldFindAndContain("active-tab", "Confirm"),
+  shouldNotExist("hourly-cost"),
+  shouldFindAndContain(
+    "error-msg",
+    `Must be an owner of the organization '${ownerName}' to calculate deployment costs.`,
+  ),
   shouldFindAndScrollTo("create-deployment-button"),
 ];


### PR DESCRIPTION
The hosted pricing multiplier now defaults to 10x ([ld#24130](https://github.com/dolthub/ld/pull/24130) plus the `CalcCost` changes that use the billing owner's multiplier), which broke the create deployment cost assertions in two ways.

**Default quote changed.** m4.large + 100GB EBS GP3 goes from `$0.67/hour` to `$1.11/hour` (`10 × (0.100 + 0.010959)`). `testConfirmTab`'s default is updated, and the `cost` parameter stays for owners grandfathered into a lower multiplier.

**Quoting a cost now requires org-owner permission.** `fromBackup`, `fromExistingDep` and `withWebpki` build a deployment under `automated_testing` and assert `no-perm-banner` is visible, so they now get `Must be an owner of the organization 'automated_testing' to calculate deployment costs.` in place of the cost breakdown. They use the new `testConfirmTabWithoutCostPerms` for that.

`pricingParams.spec.ts` is untouched — trial pricing is hardcoded at $50/month, so it is unaffected by the multiplier.

## Testing

`cypress/e2e/privatePaths/render/createDeployment/**` — 20/20 passing against both prod and dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)